### PR TITLE
Handle `-s` option correctly in `main.c`

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 	ld_data_t *ld;
 
 	ld_opt_init(&opt);
-	while ((c = ketopt(&o, argc, argv, 1, "k:w:e:t:fvag:b:", 0)) >= 0) {
+	while ((c = ketopt(&o, argc, argv, 1, "k:w:e:t:fvag:s:", 0)) >= 0) {
 		if (c == 'k') opt.kmer = atoi(o.arg);
 		else if (c == 'w') opt.ws = atoi(o.arg);
 		else if (c == 't') opt.thres = atof(o.arg);
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 		else if (c == 'g') opt.gc = atof(o.arg);
 		else if (c == 'a') opt.approx = 1;
 		else if (c == 'f') for_only = 1;
-		else if (c == 'b') opt.min_start_cnt = atoi(o.arg);
+		else if (c == 's') opt.min_start_cnt = atoi(o.arg);
 		else if (c == 'v') {
 			puts(LD_VERSION);
 			return 0;


### PR DESCRIPTION
While working on a [Rust port of Longdust for pyDustmasker](https://github.com/apcamargo/pydustmasker/pull/7), I noticed that using the `-s` option caused `longdust` to exit early without processing any input.

The CLI usage text says that `-s` sets the minimum start k-mer count, but the option parser was actually checking for `-b`, so `-s` was ignored. This PR fixes the issue by updating `main.c` to parse `-s` instead of `-b`.